### PR TITLE
Fix the issue with bone indices that exceeded the max bone limit for vertex formats

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1314,7 +1314,9 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
         VertexCls = VERTEX_FORMATS_MAPPER.get(vertex_format)
         vtx_stride = VertexCls().size_
 
-    MAX_BONES = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)  # enforced in `_process_weights_for_export`
+    MAX_BONES = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
+    if max_bones_per_vertex > MAX_BONES:
+        max_bones_per_vertex = MAX_BONES
     weight_half_float = (dst_mod.header.version in (210, 211, 212) and
                          vertex_format not in VERTEX_FORMATS_BRIDGE)
     weights_per_vertex = _process_weights_for_export(
@@ -1481,7 +1483,7 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
             else:
                 bone_indices = [bi for bi, _ in weights_data]
             # fill empty bone indices with the first bone id
-            bone_indices.extend([bone_indices[0]] * (max_bones_per_vertex - len(bone_indices)))
+            bone_indices.extend([bone_indices[0]] * (MAX_BONES - len(bone_indices)))
             bone_indices.extend([0] * (MAX_BONES - len(bone_indices)))
             if vertex_format == 0xdb7da014:  # very strange bridge format
                 bone_indices.insert(1, 128)

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1315,6 +1315,7 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
         vtx_stride = VertexCls().size_
 
     MAX_BONES = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
+    # It breaks index serealization without clamping
     if max_bones_per_vertex > MAX_BONES:
         max_bones_per_vertex = MAX_BONES
     weight_half_float = (dst_mod.header.version in (210, 211, 212) and
@@ -1482,8 +1483,9 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
                     bone_index) for bone_index, _ in weights_data]
             else:
                 bone_indices = [bi for bi, _ in weights_data]
-            # fill empty bone indices with the first bone id
-            bone_indices.extend([bone_indices[0]] * (MAX_BONES - len(bone_indices)))
+            # minmics ingame files pattern if vertex has less than max_bones_per_vertex influences
+            bone_indices.extend([bone_indices[0]] * (max_bones_per_vertex - len(bone_indices)))
+            # fill other empty bone indices in vertex format range with 0
             bone_indices.extend([0] * (MAX_BONES - len(bone_indices)))
             if vertex_format == 0xdb7da014:  # very strange bridge format
                 bone_indices.insert(1, 128)


### PR DESCRIPTION
Turned out, despite skin weights serialization code successfully limiting total number of bones per vertex, max_bones_per_vertex remained the same and it broke indices serialization in certain cases